### PR TITLE
added governor event listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
     <main id="main-container">
 
     </main>
+
+    <div id="colonyMineralContainer">
+        <h2 id="colonyMineralHeader">Colony Minerals</h2>
+    </div>
     <script type="module" src="./scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/TransientState.js
+++ b/scripts/TransientState.js
@@ -3,10 +3,20 @@
 //mineralId = 0
 //mineralAmount = 0
 
+export const colonyState = {
+    "colonyId": 0,
+    "mineralId": 0,
+    "mineralAmount": 0
+}
+
 //initial facilityMinerals
 //facilityId = 0
 //mineralId = 0
 //mineralAmount = 0 
+
+export const setColonyId = (id) => {
+    colonyState.colonyId = id
+}
 
 
 

--- a/scripts/colonyMinerals.js
+++ b/scripts/colonyMinerals.js
@@ -7,16 +7,31 @@
 //list mineral inventory
 //-------------------------------
 
-//import governor data from manager
+
 //import colonyMinerals data from manager
+import { getColonyMinerals } from "./managers/colonyMineralsManager.js";
+import { colonyState } from "./TransientState.js";
 
 
-//define getColonyMinerals
+//define colonyMineralList
 
-    //set governors to variable
-    //set colonyMinerals to variable
+export const colonyMineralList = async () => {
+     //set colonyMinerals to variable
+    const colonyMinerals = await getColonyMinerals()
 
-    //if transientState.colonyId = colonyMinerals.colonyId
+    const colonyMineralHTML = colonyMinerals.map(mineral => {
+        //if transientState.colonyId = colonyMinerals.colonyId
+        if (colonyState.colonyId === mineral.colonyId) {
+            return `
+                <h2>${mineral.colony.name}</h2>
+                <div>${mineral.mineralAmount} tons of ${mineral.mineral.name}</div>
+            `
+        }
+    }).join("")
+
+    return colonyMineralHTML
+
+    
 
         //document.getElementbyId(colonyMinerals).textContent = colonyMinerals.colony.name
 
@@ -24,3 +39,8 @@
         //print colonyMinerals.mineral.name
         //print colonyMinerals.mineralAmount
         //<ul>
+
+}
+
+    
+   

--- a/scripts/facilities.js
+++ b/scripts/facilities.js
@@ -10,7 +10,7 @@ export const facilityList = async () => {
                     //<option disabled selected>Choose facility</option>
     let html = `
                 <h2>Choose facility</h2>
-                <select id="facilitySelect" name="facility">
+                <select id="facilitySelect" name="facility" disabled>
                 <option disabled selected>Choose facility</option> 
     `
     //map facilitys array

--- a/scripts/governors.js
+++ b/scripts/governors.js
@@ -1,12 +1,14 @@
 //import governor data from governor manager
 
+import { colonyMineralList } from "./colonyMinerals.js";
 import { getGovernors } from "./managers/governorManager.js";
+import { setColonyId } from "./TransientState.js";
 
 //define a function to get HTML for governor select element
 
 export const governorsList = async () => {
     //add change event listener handleGovernorChoice
-    // document.addEventListener("change", handleGovernorChoice)
+    document.addEventListener("change", handleGovernorChoice)
     //save governor data to a varaible
     const governors = await getGovernors()
 
@@ -33,8 +35,13 @@ export const governorsList = async () => {
 
     
 
-//define event listener handleGovernorChoice
-    //if target name === governors
-    //setGovernor(parseInt(governorId))
-    //document.getElementById("facilitySelect").diabled = !this.value
-    //invoke getColonyMinerals()
+const handleGovernorChoice = async (e) => {
+    if (e.target.name === "governors") {
+        setColonyId(parseInt(e.target.value))
+        document.getElementById("facilitySelect").disabled = false
+    //invoke getColonyMinerals
+        document.getElementById("colonyMineralContainer").innerHTML = await colonyMineralList()
+    }
+    
+}
+    

--- a/scripts/managers/colonyMineralsManager.js
+++ b/scripts/managers/colonyMineralsManager.js
@@ -1,1 +1,7 @@
 //dont forget to expand colony and mineral!!!!!
+
+export const getColonyMinerals = async () => {
+    const response = await fetch("http://localhost:8088/colonyMinerals?_expand=colony&_expand=mineral")
+    const colonyMinerals = await response.json()
+    return colonyMinerals
+}


### PR DESCRIPTION
# Description

Added change event listener for the governors module. On governor change, the facility select element becomes enabled. Also the name of the colony and their mineral inventory are displayed

continued work on issue #11 


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Should I Test This?

Selecting a governor enables the facility select element. Every time a different governor is chosen, a different colony and inventory is displayed.

# Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no errors
